### PR TITLE
Allowing for workflow dispatch from Google AppScript.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch: 
+    inputs: 
+      tags:
+        description: "Google AppScript Trigger for Deployment"
+        required: false
+        type: string
 
 permissions:
   id-token: write


### PR DESCRIPTION
Enable workflow dispatch for Google AppScript trigger. 

Context: workflows are configured to only run on the master branch, so this must be enabled before testing of the Google AppScript trigger can run. 

Note: For non-proof of concept purposes, would recommend requiring an environment variable input variable so that changes could be tested for deployment to TEST/ DEV only environments and prevent any interruptions to PROD/STAGE environments. 